### PR TITLE
remove @vue/compiler-sfc

### DIFF
--- a/stubs/package.json
+++ b/stubs/package.json
@@ -13,7 +13,6 @@
         "@tailwindcss/forms": "^0.5.0",
         "@tailwindcss/typography": "^0.5.2",
         "@vitejs/plugin-vue": "^2.3.1",
-        "@vue/compiler-sfc": "^3.2.33",
         "autoprefixer": "^10.4.5",
         "axios": "^0.27",
         "lodash": "^4.17.21",


### PR DESCRIPTION
As of 3.2.13+, this package is included as a dependency of the main vue package and can be accessed as vue/compiler-sfc. This means you no longer need to explicitly install this package and ensure its version match that of vue's. Just use the main vue/compiler-sfc deep import instead.